### PR TITLE
Fix <hello-world> tag

### DIFF
--- a/app.tag
+++ b/app.tag
@@ -1,9 +1,0 @@
-<hello-world>
-<!--trim is not working-->
-  <p> { opts.greet } <trim value = "{ what }" length="3">!</p>
-  this.what = "Hoodie"
-</hello-world>
-
-<trim>
-   <span>{ opt.value.substr(0, opts.length)}</span>
-</trim>

--- a/tags/hello-world.js
+++ b/tags/hello-world.js
@@ -1,2 +1,6 @@
-riot.tag2('hello-world', '<h3>Hello {opts.greet}</h3>', '', '', function(opts) {
+riot.tag2('hello-world', '<p> {opts.greet} <trim value="{what}" length="3">!</p>', '', '', function(opts) {
+  this.what = "Hoodie"
+});
+
+riot.tag2('trim', '<span>{opts.value.substr(0, opts.length)}</span>', '', '', function(opts) {
 });

--- a/tags/hello-world.tag
+++ b/tags/hello-world.tag
@@ -1,3 +1,9 @@
 <hello-world>
-  <h3>Hello {opts.greet}</h3>
+<!--trim is not working-->
+  <p> { opts.greet } <trim value = "{ what }" length="3">!</p>
+  this.what = "Hoodie"
 </hello-world>
+
+<trim>
+   <span>{ opts.value.substr(0, opts.length)}</span>
+</trim>


### PR DESCRIPTION
Hey @flyjwayur,

the problem was that the `app.tag` file was no longer used :) 

In the `index.html` file you have

``` html
<script src="tags/hello-world.js"></script>
  <script>
  riot.mount('hello-world', { greet:'Joe' })
  </script>
```

So your app is now using `tags/hello-world.js`. I’ve updated `tags/hello-world.tag` and then compiled it with the [compiler](http://riotjs.com/guide/compiler/). When you start the compiler with `riot -w tags` it compiles everytime you change a `*.tag` file in the `tags` folder

Does that make sense?
